### PR TITLE
Fix TypeError when running CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,14 @@ cache:
 language: php
 php:
   - '7.4'
-  - '8.0'
-
-jobs:
-  allow_failures:
-    - php: 8.0
 
 branches:
   only:
-    - master
     - develop
+    - "/^.*[Ff]eature\\/.*$/"
+    - "/^.*[rR]elease\\/.*$/"
+    - "/^.*[bB]ug\\/.*$/"
+    - "/^.*[Hh]otfix\\/.*$/"
 
 env:
   global:
@@ -39,13 +37,6 @@ install:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - export DEV_BIN_PATH=bin
   - source $DEV_BIN_PATH/create-all-branches.sh
-  - |
-    # Remove Xdebug for a huge performance increase:
-    if [ -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ]; then
-      phpenv config-rm xdebug.ini
-    else
-      echo "xdebug.ini does not exist"
-    fi
   - composer require --dev --no-update roots/wordpress:${WP_VERSION} wp-phpunit/wp-phpunit:${WP_VERSION}
   - composer update --prefer-dist --no-interaction --prefer-stable --no-suggest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [2.5.1] - 2021-11-02
+- Fix: Add `--user` flag as option for CLI request, defaulting to `0` to avoid error on completed model. 
+
 ## [2.5.0] - 2021-11-01
 - Update: PHP minimum version is now `7.4`.
 - Change: The CLI command to run all tasks is now: `$ wp upgrade-task-runner`.

--- a/src/Cli/DispatchTasks.php
+++ b/src/Cli/DispatchTasks.php
@@ -52,6 +52,12 @@ class DispatchTasks implements WpHooksInterface
      *
      * [--task=<class>]
      * : The fully qualified registered task to run.
+     * ---
+     *
+     * [--user=<id>]
+     * : The user ID to associate with running said task(s).
+     * ---
+     *
      * @param mixed $args
      * @param mixed $assoc_args
      * @phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter
@@ -83,6 +89,7 @@ class DispatchTasks implements WpHooksInterface
                 if (\is_string($task) && !empty($task) && $option_key !== $sanitize($task)) {
                     continue;
                 }
+                $field->setUserId(\absint(get_flag_value($assoc_args, 'user', 0)));
                 $field->getTaskRunner()->dispatch($field);
                 $run[] = \get_class($field);
             }

--- a/upgrade-task-runner.php
+++ b/upgrade-task-runner.php
@@ -6,7 +6,7 @@
  * Plugin Name: Upgrade Task Runner
  * Plugin URI: https://github.com/thefrosty/wp-upgrade-task-runner
  * Description: A WordPress plugin for developers to write custom migration tasks.
- * Version: 2.5.0
+ * Version: 2.5.1
  * Author: Austin Passy
  * Author URI: https://github.com/thefrosty
  * Requires at least: 5.4


### PR DESCRIPTION
Resolves the `PHP Fatal error:  Uncaught TypeError: Return value of TheFrosty\WpUpgradeTaskRunner\Models\UpgradeModel::getUserId() must be of the type int, null returned in /usr/local/wordpress/wp-content/plugins/wp-upgrade-task-runner/src/Models/UpgradeModel.php:134`